### PR TITLE
fix: remove floating discord button and align footer socials

### DIFF
--- a/client/src/components/navbar.tsx
+++ b/client/src/components/navbar.tsx
@@ -121,7 +121,6 @@ export const Navbar = () => {
                 {showSignout && <a onClick={signOut}>Sign out</a>}
             </div>
             <h1 className={`${isMenuOpen? 'text-black' : 'text-white'} fixed z-50 top-4 right-4 text-3xl lg:hidden flex`} onClick={() => {toggleMenu()}}>{isMenuOpen ? 'X' : '☰'}</h1>
-            <a className='bottom-4 left-4 z-[100] fixed !fill-white w-12 h-12 !text-white' target='_blank' href="https://discord.gg/yRShGV7Py4"><FontAwesomeIcon className="w-full h-full text-white" icon={faDiscord} /></a>
         </div>
     )
 }

--- a/client/src/features/footer/apply-page/Footer.tsx
+++ b/client/src/features/footer/apply-page/Footer.tsx
@@ -39,7 +39,9 @@ export default function Footer() {
             </div>
             <div className="bottom-6 left-0 z-30 absolute w-full px-4 sm:px-8 lg:px-20">
                 <div className="flex justify-between items-center w-full">
-                    <div className="flex items-center gap-3 sm:gap-4">
+                    {/* Negative margin cancels the per-icon mx in Socials so the row sits flush
+                        with this container's horizontal padding instead of double-indented. */}
+                    <div className="flex items-center gap-3 sm:gap-4 -ml-3 sm:-ml-4">
                         <Socials baseColor="text-white" hoverColor="hover:text-navyblue"/>
                     </div>
                     <div className="flex items-center gap-3 sm:gap-4">


### PR DESCRIPTION
Remove the fixed bottom-left Discord icon from the navbar. The Discord link in the nav menu and the footer socials row are unaffected.

Nudge the footer socials left by cancelling the per-icon horizontal margin from the Socials component, so the row sits flush with the footer container padding. Applied at the Footer wrapper rather than in Socials itself, since that component is shared with the mailing unsubscribe page.